### PR TITLE
fix: 첫 페이지에서 ContentMenu가 보이던 버그 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,7 +26,7 @@ export default async function RootLayout({
   children: React.ReactNode;
   params: Promise<{ slug: string | undefined }>;
 }>) {
-  const slug = await params;
+  const { slug } = await params;
   const posts = await getPosts();
 
   return (


### PR DESCRIPTION
## 주요 수정사항


- 첫 페이지와 포스트 페이지에서 보이는 내비게이션 메뉴가 달라야 합니다.
  - 첫 페이지에서는 `PostMenu` 만 보여줌.
  - 포스트 페이지에서는 `PostMenu`, `ContentMenu`를 보여줌.

- 첫 페이지에서도 `ContentMenu`가 보이던 버그를 수정합니다.

### 원인

- 리팩토링 과정에서 페이지마다 내비게이션 타입을 구분하는 로직을 추가하였습니다.

- 이 후 `params.slug` 에 대해서 페이지를 구분해야 합니다.

- 그러나 `params.slug` 가 아닌 `params` 를 대상으로 비교하여 `slug != null` 이라는 로직이 제대로 동작하지 않았습니다.

### 해결 방법

- 레이아웃에서 `params`의 결과를 `destructuring` 합니다.

## 테스트 증적

- **AS-IS**

![스크린샷 2025-01-27 오후 10 26 22](https://github.com/user-attachments/assets/ec0999ff-4725-48c7-9795-26a062a6e5d1)



- **TO-BE**



![스크린샷 2025-01-27 오후 10 26 32](https://github.com/user-attachments/assets/05fe4e8a-11e3-4914-8e5d-ab52051cfbc2)
