### PR TITLE
feat: 코드 테마 추가

### DIFF
--- a/src/components/post/PageContent/PrismLight.tsx
+++ b/src/components/post/PageContent/PrismLight.tsx
@@ -1,0 +1,10 @@
+import { PrismLight } from "react-syntax-highlighter";
+import javascript from "react-syntax-highlighter/dist/esm/languages/prism/javascript";
+import typescript from "react-syntax-highlighter/dist/esm/languages/prism/typescript";
+import bash from "react-syntax-highlighter/dist/esm/languages/prism/bash";
+
+PrismLight.registerLanguage("javascript", javascript);
+PrismLight.registerLanguage("typescript", typescript);
+PrismLight.registerLanguage("bash", bash);
+
+export default PrismLight;

--- a/src/components/post/PageContent/markdownComponents.tsx
+++ b/src/components/post/PageContent/markdownComponents.tsx
@@ -1,7 +1,7 @@
 import { Children } from "react";
 import { ReactNode } from "react";
 import { Components } from "react-markdown";
-import { PrismLight } from "react-syntax-highlighter";
+import PrismLight from "./PrismLight";
 import { materialOceanic } from "react-syntax-highlighter/dist/esm/styles/prism";
 
 const customStyle = {


### PR DESCRIPTION
## 주요 수정사항

- 코드 마크다운에 다음 언어에 대한 테마를 추가합니다.
  - javascript
  - typescript
  - bash

## 테스트 증적

![스크린샷 2025-02-06 오전 6 07 06](https://github.com/user-attachments/assets/08473173-6d2d-43d1-bff7-5cf7e31f4f2b)